### PR TITLE
Read .cmt files from .bsb.

### DIFF
--- a/src/analyze_fixture_tests/TestDefinition.re
+++ b/src/analyze_fixture_tests/TestDefinition.re
@@ -28,7 +28,7 @@ let getOutput = (~projectDir, files, mainFile) => {
       | _ => ()
     };
     switch result {
-      | Success(_, {extra}) => Log.log(SharedTypes.showExtra(extra));
+      | Success(_, {extra}, _) => Log.log(SharedTypes.showExtra(extra));
       | TypeError(text, _) => {
         print_endline("Module: " ++ modname);
         print_endline(text);

--- a/src/analyze_fixture_tests/TestHover.re
+++ b/src/analyze_fixture_tests/TestHover.re
@@ -31,7 +31,7 @@ let getOutput = (~projectDir, files, mainFile) => {
       | _ => ()
     };
     switch result {
-      | Success(_, {extra}) => Log.log(SharedTypes.showExtra(extra));
+      | Success(_, {extra}, _) => Log.log(SharedTypes.showExtra(extra));
       | TypeError(text, _) => {
         print_endline("Module: " ++ modname);
         print_endline(text);

--- a/src/analyze_fixture_tests/TestReferences.re
+++ b/src/analyze_fixture_tests/TestReferences.re
@@ -14,7 +14,7 @@ let getOutput = (~projectDir, files, mainFile) => {
     let uri = TestUtils.uriForName(name);
     let%try_force result = State.getCompilationResult(uri, state, ~package);
     switch result {
-      | Success(_, {file, extra}) => {
+      | Success(_, {file, extra}, _) => {
         Log.log(uri);
         Log.log(SharedTypes.showExtra(extra));
 

--- a/src/full_tests/FullTests.re
+++ b/src/full_tests/FullTests.re
@@ -23,7 +23,7 @@ files->Belt.List.forEach(fileName => {
     | Ok(package) => switch (State.getCompilationResult(uri, state, ~package)) {
       | Error(message) =>
         print_endline("  Invalid compilation result: " ++ message);
-      | Ok(Success(_message, {file, extra})) =>
+      | Ok(Success(_message, {file, extra}, _)) =>
         extra.locations->Belt.List.forEach(((location, loc)) => {
           switch loc {
             // Skip builtin types

--- a/src/lsp/Diagnostics.re
+++ b/src/lsp/Diagnostics.re
@@ -52,7 +52,7 @@ let runDiagnostics = (uri, state, ~package) => {
       let errors = ErrorParser.parseErrors(Utils.splitLines(Utils.stripAnsii(text))) @ errors;
       l(errors |. Belt.List.keepMap(makeDiagnostic(documentText)))
     }
-    | Success(text, _) => {
+    | Success(text, _, _) => {
       if (String.trim(text) == "") {
         l([])
       } else {

--- a/src/lsp/Main.re
+++ b/src/lsp/Main.re
@@ -140,7 +140,7 @@ let processFile = (~state, ~uri, ~quiet) => {
     | Error(message) =>
       print_endline("  Invalid compilation result: " ++ message);
       Some((package, None));
-    | Ok(Success(_message, contents)) =>
+    | Ok(Success(_message, contents, _)) =>
       if (!quiet) {
         print_endline("  Good: " ++ uri);
       };

--- a/src/lsp/MessageHandlers.re
+++ b/src/lsp/MessageHandlers.re
@@ -356,7 +356,7 @@ let handlers: list((string, (state, Json.t) => result((state, Json.t), string)))
 
       let items = {
         let full = switch (State.getCompilationResult(uri, state, ~package)) {
-          | Ok(Success(_, full)) => {
+          | Ok(Success(_, full, _)) => {
             Ok(Some(full))
           }
           | Ok(_) => Ok(State.getLastDefinitions(uri, state))


### PR DESCRIPTION
Read .cmt fies from lib/bs in case of .res files (simplified version assuming there's only src), and use their mtime to invalidate the cache.